### PR TITLE
Pivot initialization of prolog translator / translator fix

### DIFF
--- a/DataFlowSystemModel.edit/plugin.properties
+++ b/DataFlowSystemModel.edit/plugin.properties
@@ -108,3 +108,5 @@ _UI_DefaultStateRef_type = Default State Ref
 _UI_DefaultStateRef_stateVariable_feature = State Variable
 _UI_DefaultStateRef_attribute_feature = Attribute
 _UI_DefaultStateRef_value_feature = Value
+_UI_VariableAssignment_isAttributeWildcard_feature = Is Attribute Wildcard
+_UI_VariableAssignment_isValueWildcard_feature = Is Value Wildcard

--- a/DataFlowSystemModel.edit/src-gen/edu/kit/ipd/sdq/dataflow/systemmodel/provider/VariableAssignmentItemProvider.java
+++ b/DataFlowSystemModel.edit/src-gen/edu/kit/ipd/sdq/dataflow/systemmodel/provider/VariableAssignmentItemProvider.java
@@ -62,6 +62,8 @@ public class VariableAssignmentItemProvider extends ItemProviderAdapter implemen
 			addVariablePropertyDescriptor(object);
 			addAttributePropertyDescriptor(object);
 			addValuePropertyDescriptor(object);
+			addIsAttributeWildcardPropertyDescriptor(object);
+			addIsValueWildcardPropertyDescriptor(object);
 		}
 		return itemPropertyDescriptors;
 	}
@@ -128,6 +130,38 @@ public class VariableAssignmentItemProvider extends ItemProviderAdapter implemen
 						return ((VariableAssignment) thisObject).getPossibleValues();
 					}
 				});
+	}
+
+	/**
+	 * This adds a property descriptor for the Is Attribute Wildcard feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addIsAttributeWildcardPropertyDescriptor(Object object) {
+		itemPropertyDescriptors
+				.add(createItemPropertyDescriptor(((ComposeableAdapterFactory) adapterFactory).getRootAdapterFactory(),
+						getResourceLocator(), getString("_UI_VariableAssignment_isAttributeWildcard_feature"),
+						getString("_UI_PropertyDescriptor_description",
+								"_UI_VariableAssignment_isAttributeWildcard_feature", "_UI_VariableAssignment_type"),
+						SystemModelPackage.Literals.VARIABLE_ASSIGNMENT__IS_ATTRIBUTE_WILDCARD, false, false, false,
+						ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Is Value Wildcard feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addIsValueWildcardPropertyDescriptor(Object object) {
+		itemPropertyDescriptors
+				.add(createItemPropertyDescriptor(((ComposeableAdapterFactory) adapterFactory).getRootAdapterFactory(),
+						getResourceLocator(), getString("_UI_VariableAssignment_isValueWildcard_feature"),
+						getString("_UI_PropertyDescriptor_description",
+								"_UI_VariableAssignment_isValueWildcard_feature", "_UI_VariableAssignment_type"),
+						SystemModelPackage.Literals.VARIABLE_ASSIGNMENT__IS_VALUE_WILDCARD, false, false, false,
+						ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, null, null));
 	}
 
 	/**
@@ -212,6 +246,8 @@ public class VariableAssignmentItemProvider extends ItemProviderAdapter implemen
 		case SystemModelPackage.VARIABLE_ASSIGNMENT__VARIABLE:
 		case SystemModelPackage.VARIABLE_ASSIGNMENT__ATTRIBUTE:
 		case SystemModelPackage.VARIABLE_ASSIGNMENT__VALUE:
+		case SystemModelPackage.VARIABLE_ASSIGNMENT__IS_ATTRIBUTE_WILDCARD:
+		case SystemModelPackage.VARIABLE_ASSIGNMENT__IS_VALUE_WILDCARD:
 			fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 			return;
 		case SystemModelPackage.VARIABLE_ASSIGNMENT__TERM:

--- a/DataFlowSystemModel/META-INF/MANIFEST.MF
+++ b/DataFlowSystemModel/META-INF/MANIFEST.MF
@@ -2,6 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: DataFlowSystemModel;singleton:=true
+Automatic-Module-Name: DataFlowSystemModel
 Bundle-Version: 0.1.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
@@ -11,5 +12,5 @@ Export-Package: edu.kit.ipd.sdq.dataflow.systemmodel,
  edu.kit.ipd.sdq.dataflow.systemmodel.impl,
  edu.kit.ipd.sdq.dataflow.systemmodel.util
 Require-Bundle: org.eclipse.emf.ecore;visibility:=reexport,
- org.eclipse.core.runtime
+ org.eclipse.core.runtime;visibility:=reexport
 Bundle-ActivationPolicy: lazy

--- a/PrologTranslator/META-INF/MANIFEST.MF
+++ b/PrologTranslator/META-INF/MANIFEST.MF
@@ -6,4 +6,8 @@ Bundle-Version: 1.0.0.qualifier
 Export-Package: .,
  edu.kit.ipd.sdq.dataflow.systemmodel
 Require-Bundle: DataFlowSystemModel;bundle-version="0.1.0",
- org.eclipse.emf.ecore.xmi;bundle-version="2.13.0"
+ org.eclipse.emf.ecore.xmi;bundle-version="2.13.0",
+ org.eclipse.ocl.pivot;bundle-version="1.4.0",
+ org.apache.log4j;bundle-version="1.2.15",
+ com.google.inject;bundle-version="3.0.0",
+ org.eclipse.ocl.xtext.completeocl;bundle-version="1.4.0"

--- a/PrologTranslator/src/Main.xtend
+++ b/PrologTranslator/src/Main.xtend
@@ -8,10 +8,14 @@ import org.eclipse.emf.ecore.resource.Resource
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceFactoryImpl
 import edu.kit.ipd.sdq.dataflow.systemmodel.Configuration
+import org.eclipse.ocl.pivot.utilities.PivotStandaloneSetup
+import org.eclipse.ocl.xtext.completeocl.CompleteOCLStandaloneSetup
 
 class Main {
 	
 	def static System loadSystem(String filePath) {
+		PivotStandaloneSetup.doSetup();
+		CompleteOCLStandaloneSetup.doSetup();
 		SystemModelPackage.eINSTANCE.eClass();
         val reg = Resource.Factory.Registry.INSTANCE;
       	reg.getExtensionToFactoryMap().put("*", new XMIResourceFactoryImpl());

--- a/PrologTranslator/src/edu/kit/ipd/sdq/dataflow/systemmodel/AssignmentsTranslator.xtend
+++ b/PrologTranslator/src/edu/kit/ipd/sdq/dataflow/systemmodel/AssignmentsTranslator.xtend
@@ -189,7 +189,7 @@ class AssignmentsTranslator {
 			for(precond : preconditions.get()) {
 				preconditionsPrefix += precond.getPredicateForRestriction(attrib) + ",";
 			}
-			preconditionsPrefix = preconditions + "!,";
+			preconditionsPrefix = preconditionsPrefix + "!,";
 		}
 		
 		var String pred = assiContext.predicate.getPredicate(ltContext.currentStack,assi.variable,attrib,value);


### PR DESCRIPTION
The prolog translator did not work in standalone mode because of missing initialization of the pivot engine. This results in a NPE when accessing derived features.

Additionally, the edit code was not up to date.

The prolog translator had a bug that prevented proper serialization of preconditions.